### PR TITLE
11 validate turn order

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -82,7 +82,8 @@ async def websocket_connection(websocket: WebSocket, game_uuid: str,
 
                     # Player move
                     elif (data["type"] == "move"):
-                        if (validate_turn_order(message, clientSuspect)):
+                        # Validate turn order
+                        if (message["current_turn"] == clientSuspect):
                             game.move(data["suspect"], data["location"])
 
                             ### uncomment to see turn error message on a valid turn
@@ -95,7 +96,8 @@ async def websocket_connection(websocket: WebSocket, game_uuid: str,
 
                     # Player accusation
                     elif (data["type"] == "accusation"):
-                        if (validate_turn_order(message, clientSuspect)):
+                        # Validate turn order
+                        if (message["current_turn"] == clientSuspect):
                             data.pop("type")
                             game.make_accusation(clientSuspect, data)
                         else:
@@ -104,7 +106,8 @@ async def websocket_connection(websocket: WebSocket, game_uuid: str,
 
                     # Player suggestion
                     elif (data["type"] == "suggestion"):
-                        if (validate_turn_order(message, clientSuspect)):
+                        # Validate turn order
+                        if (message["current_turn"] == clientSuspect):
                             # Handle suggestion
                             pass
                         else:
@@ -124,7 +127,3 @@ async def websocket_connection(websocket: WebSocket, game_uuid: str,
     else:
         # this game doesn't exist
         await websocket.close(code=404)
-
-
-def validate_turn_order(message, clientSuspect):
-    return (message["current_turn"] == clientSuspect)

--- a/web/components/Canvas/Board/Board.jsx
+++ b/web/components/Canvas/Board/Board.jsx
@@ -53,6 +53,9 @@ function Board() {
             return { ...prevGameState, ...new_state };
           });
         }
+        else if (new_state.type === "turn_error") {
+          alert("Error: It is not your turn!");
+        }
       });
     }
   }, [websocket]);


### PR DESCRIPTION
- Validated turn order on the "move", "accusation", and "suggestion" message types (also added stub for "suggestion" message handling)
- Front end sends a browser alert if it's not your turn

You can test this yourself by doing one of two things:
1. There's a commented-out block in server.py that you can uncomment to have a "not your turn" message sent on a valid move, just so you can see it working. (The turn will still go through)
2. Start two games instead of having the second player join by game id. The game instance weirdness that we never fixed will make the second player get a "not your turn" error when they try to take their turn.
