### PR TITLE
25 end turn

### DIFF
--- a/api/game/clueless.py
+++ b/api/game/clueless.py
@@ -296,6 +296,7 @@ class Clueless:
         return next_player
 
     def rotate_next_player(self, player: str) -> str:
+        self.state["previous_move"] = player + " ended_turn"
         self.state["current_turn"] = self.get_next_player(player)
         return self.state["current_turn"]
 

--- a/api/game/clueless.py
+++ b/api/game/clueless.py
@@ -322,6 +322,6 @@ class Clueless:
         if location in self.allowed_moves(player):
             self.state["previous_move"] = player + " moved to " + location
             self.state["suspect_locations"][player] = location
-            self.rotate_next_player(player)
+            #self.rotate_next_player(player)
         # else:
         # todo return error?

--- a/api/server.py
+++ b/api/server.py
@@ -77,6 +77,8 @@ async def websocket_connection(websocket: WebSocket, game_uuid: str,
                     elif (data["type"] == "accusation"):
                         data.pop("type")
                         game.make_accusation(clientSuspect, data)
+                    elif (data["type"] == "end_turn"):
+                        game.rotate_next_player(clientSuspect)
                     # handle other types of messages
                     # pick character
                     # move

--- a/web/components/Canvas/Sidebar/Controls/Controls.jsx
+++ b/web/components/Canvas/Sidebar/Controls/Controls.jsx
@@ -53,6 +53,7 @@ function Controls() {
 
     const clientSuspect = (gameState?.assignments || {})[`${clientId}`];
     const currentRoom = (gameState?.suspect_locations || {})[clientSuspect];
+    const previousMove = gameState?.previous_move;
     const [action, setAction] = useState("");
     const [accusation, currentAccusation] = useState({});
 
@@ -92,7 +93,8 @@ function Controls() {
                                 onClick={() => {
                                     setAction("move");
                                 }}
-                                disabled={isControlsLocked}
+                                disabled={isControlsLocked
+                                    || String(previousMove).includes(clientSuspect)}
                                 size="large"
                             >
                                 Move
@@ -161,7 +163,7 @@ function Controls() {
                 })
             }
 
-            {gameState.game_phase === 1 && action == "end_turn" (
+            {gameState.game_phase === 1 && action == "end_turn" && (
                 <Button
                 key="end_turn"
                 variant="outlined"
@@ -174,6 +176,7 @@ function Controls() {
                 }}
                 disabled={isControlsLocked}
                 >
+                    Submit
                 </Button>
             )}
 

--- a/web/components/Canvas/Sidebar/Controls/Controls.jsx
+++ b/web/components/Canvas/Sidebar/Controls/Controls.jsx
@@ -121,6 +121,17 @@ function Controls() {
                             >
                                 Make Accusation
                             </Button>
+                            <Button
+                                id="end_turn"
+                                variant="contained"
+                                onClick={() => {
+                                    setAction("end_turn");
+                                }}
+                                disabled={isControlsLocked}
+                                size="large"
+                            >
+                                End Turn
+                            </Button>
                         </ButtonGroup>
                     </div>
                 )
@@ -150,6 +161,21 @@ function Controls() {
                 })
             }
 
+            {gameState.game_phase === 1 && action == "end_turn" (
+                <Button
+                key="end_turn"
+                variant="outlined"
+                onClick={() => {
+                    websocket?.current?.send(
+                    JSON.stringify({
+                        type: "end_turn",
+                    })
+                    );
+                }}
+                disabled={isControlsLocked}
+                >
+                </Button>
+            )}
 
             {/* todo lots of repeated code beneath, clean up */}
             {gameState.game_phase === 1 && action == "suggestion" && (


### PR DESCRIPTION
1. Allow players to make suggestions and accusations after they move.
2. Make sure players cannot move more than once per turn.
3.  Added end turn button, also allows players to skip their turn. 
Closes issue #25 