### PR TITLE
28 make player action options disappear when clicked or cancelled

### DIFF
--- a/api/game/clueless.py
+++ b/api/game/clueless.py
@@ -61,7 +61,6 @@ class Clueless:
             "ballroom_billiard",
             "library_billiard",
         ]
-        self.secret_passages = ["study_kitchen", "lounge_conservatory"]
 
         self.starting_locations = [
             "scarlet_start",
@@ -125,9 +124,14 @@ class Clueless:
         # if in room
         else:
             # could use a secret passage
-            for passage in self.secret_passages:
-                if current_loc in passage:
-                    allowed_moves.append(passage)
+            if current_loc == "study":
+                allowed_moves.append("kitchen")
+            elif current_loc == "kitchen":
+                allowed_moves.append("study")
+            elif current_loc == "lounge":
+                allowed_moves.append("conservatory")
+            elif current_loc == "conservatory":
+                allowed_moves.append("lounge")
 
             # could stay in room (if moved to current room by opponent)
             # TODO track if token was moved by a suggestion since player's last
@@ -315,7 +319,8 @@ class Clueless:
             self.state["winner"] = player
             self.state["game_phase"] = GamePhase.COMPLETED.value
         else:
-            self.state["previous_move"] = player + " made an incorrect accusation"
+            self.state[
+                "previous_move"] = player + " made an incorrect accusation"
             self.rotate_next_player(player)
             self.state["turn_order"].remove(player)
 

--- a/web/components/Canvas/Sidebar/Controls/Controls.jsx
+++ b/web/components/Canvas/Sidebar/Controls/Controls.jsx
@@ -166,16 +166,16 @@ function Controls() {
 
             {gameState.game_phase === 1 && action == "end_turn" && (
                 <Button
-                key="end_turn"
-                variant="outlined"
-                onClick={() => {
-                    websocket?.current?.send(
-                    JSON.stringify({
-                        type: "end_turn",
-                    })
-                    );
-                }}
-                disabled={isControlsLocked}
+                    key="end_turn"
+                    variant="outlined"
+                    onClick={() => {
+                        websocket?.current?.send(
+                            JSON.stringify({
+                                type: "end_turn",
+                            })
+                        );
+                    }}
+                    disabled={isControlsLocked}
                 >
                     Submit
                 </Button>
@@ -277,7 +277,7 @@ function Controls() {
                             }}
                             disabled={isControlsLocked}
                         >
-                            Cancel Suggestion
+                            Clear Suggestion
                         </Button>
                     </div>
                     <div className={styles.submission}></div>
@@ -383,7 +383,7 @@ function Controls() {
                             }}
                             disabled={isControlsLocked}
                         >
-                            Cancel Accusation
+                            Clear Accusation
                         </Button>
                     </div>
                 </div>

--- a/web/components/Canvas/Sidebar/Controls/Controls.jsx
+++ b/web/components/Canvas/Sidebar/Controls/Controls.jsx
@@ -154,6 +154,7 @@ function Controls() {
                                         location: move,
                                     })
                                 );
+                                setAction("");
                             }}
                             disabled={isControlsLocked}
                         >


### PR DESCRIPTION
Ok, this ended up being a mishmash of bug fixes instead of the actual issue title, but whatever.

- Player move options now disappear when clicked so players can't move multiple times
- Refactored secret passages. We were treating them like hallways when, after reading the rules again, I believe they should be "instant teleports" to the diagonal room. Since the secret passages weren't classified as hallways, the logic wasn't giving them the adjacent room options, and players were getting permanently stuck in the secret passage "hallways".
- I had the wrong idea of what the "cancel suggestion" button is supposed to do; since it just clears the selections, I changed the cancel button to say "Clear Suggestion" instead (same for accusations)