### PR TITLE
game ends gracefully when all players accuse wrong

### DIFF
--- a/api/game/clueless.py
+++ b/api/game/clueless.py
@@ -9,6 +9,7 @@ class GamePhase(Enum):
     NOT_STARTED = 0
     IN_PROGRESS = 1
     COMPLETED = 2
+    ENDED = 3  # Everyone failed their accusations
 
 
 class Clueless:
@@ -299,8 +300,12 @@ class Clueless:
 
         return next_player
 
-    def rotate_next_player(self, player: str) -> str:
+    def rotate_next_player(self, player: str, justAccused: bool) -> str:
         self.state["previous_move"] = player + " ended_turn"
+
+        if justAccused:
+            self.state["previous_move"] = player + " made an incorrect accusation! They are out of the game!"
+
         self.state["current_turn"] = self.get_next_player(player)
         return self.state["current_turn"]
 
@@ -319,10 +324,12 @@ class Clueless:
             self.state["winner"] = player
             self.state["game_phase"] = GamePhase.COMPLETED.value
         else:
-            self.state[
-                "previous_move"] = player + " made an incorrect accusation"
-            self.rotate_next_player(player)
+            self.rotate_next_player(player, True)
             self.state["turn_order"].remove(player)
+
+        # End the game if all players are removed from turn order
+        if not self.state["turn_order"]:
+            self.state["game_phase"] = GamePhase.ENDED.value
 
     def move(self, player: str, location: str) -> Dict:
         if location in self.allowed_moves(player):

--- a/api/server.py
+++ b/api/server.py
@@ -116,7 +116,7 @@ async def websocket_connection(websocket: WebSocket, game_uuid: str,
 
                     # End turn
                     elif (data["type"] == "end_turn"):
-                        game.rotate_next_player(clientSuspect)
+                        game.rotate_next_player(clientSuspect, False)
 
                     # handle other types of messages
                     # pick character

--- a/web/components/Canvas/Board/Board.jsx
+++ b/web/components/Canvas/Board/Board.jsx
@@ -72,7 +72,7 @@ function Board() {
       setHistory((history) => [...history, gameState?.previous_move]);
     }
 
-    if(gameState?.game_phase === 0) {
+    if (gameState?.game_phase === 0) {
       let newAssignments = {};
       for (const player in gameState?.assignments) {
         newAssignments[`${gameState?.assignments[player]}`] = player;
@@ -149,6 +149,10 @@ function Board() {
 
       {gameState.game_phase === 2 && (
         <div>Game Over! {formatLabel(gameState?.winner)} won!</div>
+      )}
+
+      {gameState.game_phase == 3 && (
+        <div>Game Over! Nobody wins!</div>
       )}
     </div>
   );


### PR DESCRIPTION
Added a new game phase to differentiate between someone winning, and no one winning. 
Also replaced the previous_move text with a special message if someone accuses wrong. The old previous_move message was getting overwritten by end_turn.
![image](https://user-images.githubusercontent.com/25755414/166593315-f1ddecd4-904b-4260-875f-82bf8c62f421.png)
