### PR TITLE
can't suggest or accuse visible cards anymore

### DIFF
--- a/api/game/clueless.py
+++ b/api/game/clueless.py
@@ -197,16 +197,12 @@ class Clueless:
                 k] + self.state["visible_cards"]
 
         # Build lists of cards for suggestion/accusation
-        self.state["selectable_cards"]["rooms"] = self.rooms
-        self.state["selectable_cards"]["suspects"] = self.suspects
-        self.state["selectable_cards"]["weapons"] = self.weapons
-        for card in self.state["visible_cards"]:
-            if card in self.state["selectable_cards"]["rooms"]:
-                self.state["selectable_cards"]["rooms"].remove(card)
-            if card in self.state["selectable_cards"]["suspects"]:
-                self.state["selectable_cards"]["suspects"].remove(card)
-            if card in self.state["selectable_cards"]["weapons"]:
-                self.state["selectable_cards"]["weapons"].remove(card)
+        self.state["selectable_cards"]["rooms"] = list(
+            set(self.rooms).difference(set(self.state["visible_cards"])))
+        self.state["selectable_cards"]["suspects"] = list(
+            set(self.suspects).difference(set(self.state["visible_cards"])))
+        self.state["selectable_cards"]["weapons"] = list(
+            set(self.weapons).difference(set(self.state["visible_cards"])))
 
         # set turn order for the game
         self.state["turn_order"] = self.generate_turn_order()

--- a/api/game/clueless.py
+++ b/api/game/clueless.py
@@ -91,10 +91,11 @@ class Clueless:
             "concealed_scenario": {},
             "player_cards": {},  # dict of player: player's card list
             "visible_cards": [],  # list of cards shown to all players
+            "selectable_cards": {},  # cards that players can suggest/accuse
             "turn_order": [],  # player turn order
             "suggestion_starter": '',
-            "suggestion_order": [], # suggestion order
-            "next_to_disprove": '', # next suspect to disprove suggestion
+            "suggestion_order": [],  # suggestion order
+            "next_to_disprove": '',  # next suspect to disprove suggestion
             "current_turn": "miss_scarlet",  # player token
             "suggestion": {},  # holds current suggestion players must disprove
             "winner": {},  # holds the winner of the game
@@ -192,14 +193,28 @@ class Clueless:
         # front-end Cards.jsx uses cards_to_display only -- not separately displaying visible + player cards
         self.state["cards_to_display"] = {}
         for k, v in self.state["player_cards"].items():
-            self.state["cards_to_display"][k] = self.state["player_cards"][k] + self.state["visible_cards"]
+            self.state["cards_to_display"][k] = self.state["player_cards"][
+                k] + self.state["visible_cards"]
+
+        # Build lists of cards for suggestion/accusation
+        self.state["selectable_cards"]["rooms"] = self.rooms
+        self.state["selectable_cards"]["suspects"] = self.suspects
+        self.state["selectable_cards"]["weapons"] = self.weapons
+        for card in self.state["visible_cards"]:
+            if card in self.state["selectable_cards"]["rooms"]:
+                self.state["selectable_cards"]["rooms"].remove(card)
+            if card in self.state["selectable_cards"]["suspects"]:
+                self.state["selectable_cards"]["suspects"].remove(card)
+            if card in self.state["selectable_cards"]["weapons"]:
+                self.state["selectable_cards"]["weapons"].remove(card)
 
         # set turn order for the game
         self.state["turn_order"] = self.generate_turn_order()
 
-        # set suggestion order for the game -- copy at start ensures 
+        # set suggestion order for the game -- copy at start ensures
         # we include players who make incorrect accusations
-        self.state["suggestion_order"] = copy.deepcopy(self.state["turn_order"])
+        self.state["suggestion_order"] = copy.deepcopy(
+            self.state["turn_order"])
 
         # get first player to move
         for token in self.players:
@@ -227,7 +242,6 @@ class Clueless:
         values = [suspect, room, weapon]
 
         return dict(zip(keys, values))
-
 
     def distribute_cards(self) -> Tuple:
         """
@@ -316,7 +330,8 @@ class Clueless:
         self.state["previous_move"] = player + " ended_turn"
 
         if justAccused:
-            self.state["previous_move"] = player + " made an incorrect accusation! They are out of the game!"
+            self.state[
+                "previous_move"] = player + " made an incorrect accusation! They are out of the game!"
 
         self.state["current_turn"] = self.get_next_player(player)
         return self.state["current_turn"]
@@ -356,11 +371,11 @@ class Clueless:
         self.state["game_phase"] = GamePhase.SUGGESTION.value
         self.state["suggestion"] = suggestion
         self.next_to_disprove(player)
-        return 
+        return
 
     def terminate_suggestion(self):
         self.state["suggestion_starter"] = ''
-        return 
+        return
 
     def next_to_disprove(self, player: str) -> str:
         """ Updates game state with next character up to disprove suggestion """

--- a/web/components/Canvas/Sidebar/Controls/Controls.jsx
+++ b/web/components/Canvas/Sidebar/Controls/Controls.jsx
@@ -23,35 +23,9 @@ function Controls(props) {
 
     const openRulesDialog = () => props.setRulesOpen(true);
 
-    const suspects = [
-        "colonel_mustard",
-        "miss_scarlet",
-        "professor_plum",
-        "mr_green",
-        "mrs_white",
-        "mrs_peacock",
-    ];
-
-    const rooms = [
-        "study",
-        "hall",
-        "lounge",
-        "library",
-        "billiard",
-        "dining",
-        "conservatory",
-        "ballroom",
-        "kitchen",
-    ];
-
-    const weapons = [
-        "rope",
-        "lead_pipe",
-        "knife",
-        "wrench",
-        "candlestick",
-        "revolver",
-    ];
+    const suspects = gameState?.selectable_cards?.suspects;
+    const rooms = gameState?.selectable_cards?.rooms;
+    const weapons = gameState?.selectable_cards?.weapons;
 
     const clientSuspect = (gameState?.assignments || {})[`${clientId}`];
     const currentRoom = (gameState?.suspect_locations || {})[clientSuspect];
@@ -92,26 +66,26 @@ function Controls(props) {
     function validateAccusationFields() {
         // only calling the hook once to avoid race condition
         let isSuspectValid = true, isRoomValid = true, isWeaponValid = true;
-        if(!accusationSuspect) isSuspectValid = false;
-        if(!accusationRoom) isRoomValid = false;
-        if(!accusationWeapon) isWeaponValid = false;
+        if (!accusationSuspect) isSuspectValid = false;
+        if (!accusationRoom) isRoomValid = false;
+        if (!accusationWeapon) isWeaponValid = false;
         setAccusationErrors({
-            "weapon" : !isWeaponValid,
-            "room" : !isRoomValid,
-            "suspect" : !isSuspectValid
+            "weapon": !isWeaponValid,
+            "room": !isRoomValid,
+            "suspect": !isSuspectValid
         })
     }
 
     function validateSuggestionFields() {
         // only calling the hook once to avoid race condition
         let isSuspectValid = true, isRoomValid = true, isWeaponValid = true;
-        if(!suggestionSuspect) isSuspectValid = false;
-        if(!suggestionRoom) isRoomValid = false;
-        if(!suggestionWeapon) isWeaponValid = false;
+        if (!suggestionSuspect) isSuspectValid = false;
+        if (!suggestionRoom) isRoomValid = false;
+        if (!suggestionWeapon) isWeaponValid = false;
         setSuggestionErrors({
-            "weapon" : !isWeaponValid,
-            "room" : !isRoomValid,
-            "suspect" : !isSuspectValid
+            "weapon": !isWeaponValid,
+            "room": !isRoomValid,
+            "suspect": !isSuspectValid
         })
     }
 
@@ -306,7 +280,7 @@ function Controls(props) {
                             key={`submit-suggestion`}
                             variant="contained"
                             onClick={() => {
-                                if(suggestionRoom && suggestionSuspect && suggestionWeapon) {
+                                if (suggestionRoom && suggestionSuspect && suggestionWeapon) {
                                     websocket?.current?.send(
                                         JSON.stringify({
                                             type: "suggestion",
@@ -428,14 +402,14 @@ function Controls(props) {
                             variant="contained"
                             onClick={() => {
                                 if (accusationSuspect && accusationRoom && accusationWeapon) {
-                                  websocket?.current?.send(
-                                    JSON.stringify({
-                                      type: "accusation",
-                                      suspect: accusationSuspect,
-                                      room: accusationRoom,
-                                      weapon: accusationWeapon,
-                                    })
-                                  );
+                                    websocket?.current?.send(
+                                        JSON.stringify({
+                                            type: "accusation",
+                                            suspect: accusationSuspect,
+                                            room: accusationRoom,
+                                            weapon: accusationWeapon,
+                                        })
+                                    );
                                 } else {
                                     validateAccusationFields()
                                 }


### PR DESCRIPTION
Sorry about all the auto-formatting in advance

New "selectable_cards" dict in the game state so we have something to send to Controls.jsx for the dropdown lists. When the game initializes it'll copy the rooms, suspects, weapons over to selectable_cards and then remove the ones found in visible_cards. 

Now Controls.jsx just gets the selectable_cards lists instead of hardcoding its own.

Thoroughly tested with 4 players so that there were 2 cards left over. The visible cards are gone from both suggestion and accusation. Not sure if I did this part, but it won't let you suggest if you're in a room that's a visible card.